### PR TITLE
Exclude orders with negative prices from available funds

### DIFF
--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -60,11 +60,11 @@ class Ordergroup < Group
   end
 
   def value_of_open_orders(exclude = nil)
-    group_orders.in_open_orders.reject { |go| go == exclude }.collect(&:price).sum
+    group_orders.in_open_orders.reject { |go| go == exclude || go.price < 0 }.collect(&:price).sum
   end
 
   def value_of_finished_orders(exclude = nil)
-    group_orders.in_finished_orders.reject { |go| go == exclude }.collect(&:price).sum
+    group_orders.in_finished_orders.reject { |go| go == exclude || go.price < 0 }.collect(&:price).sum
   end
 
   # Returns the available funds for this order group (the account_balance minus price of all non-closed GroupOrders of this group).


### PR DESCRIPTION
We and another foodcoop use the foodsoft also for deposit refunding. Therefore we have articles with negative deposit that can be ordered. These orders have a negative price and increase the available funds. This should only take place when the order is balanced. Therefore, unbalanced orders with negative price should be excluded in `value_of_open_orders` and `value_of_finished_orders`.